### PR TITLE
Check for unseen results

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,18 @@ python3 -m http.server 8000
 
 Then open `http://localhost:8000`.
 
+## Offline & PWA
+- This site includes a Service Worker for offline caching and a Web App Manifest.
+- On first load, assets are cached. Subsequent loads work offline (calculators, workout builder, nutrition tracker, and static pages). The Body Scan needs internet to fetch ML models from the CDN if not already cached.
+- To test:
+  1. Load `http://localhost:8000` once while online.
+  2. Open DevTools → Application → Service Workers and confirm `sw.js` is active.
+  3. Toggle “Offline” in the Network tab and reload the page; the app should still work.
+
+Notes:
+- Some browsers require HTTPS for Service Workers; `localhost` is allowed for development.
+- If you change files, the SW will update automatically on refresh; you can also call `navigator.serviceWorker.getRegistration().then(r=>r&&r.update())` in the console.
+
 ## Deploy to GitHub Pages
 1. Create a new public repo on GitHub (e.g., `fitness-website`).
 2. Push the contents of this folder to the repo root (so `index.html` is at the top level).

--- a/assets/icons/icon.svg
+++ b/assets/icons/icon.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <rect width="100" height="100" rx="16" fill="#07c0a2"/>
+  <text x="50" y="62" font-size="56" text-anchor="middle" fill="#ffffff" font-family="Arial, Helvetica, sans-serif">F</text>
+</svg>
+

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -393,4 +393,11 @@
     status.textContent = 'Thanks! We will get back to you soon.';
     e.target.reset();
   });
+
+  // --- Service worker registration ---
+  if ('serviceWorker' in navigator) {
+    window.addEventListener('load', () => {
+      navigator.serviceWorker.register('/sw.js').catch(() => {});
+    });
+  }
 })();

--- a/assets/js/scan.js
+++ b/assets/js/scan.js
@@ -1,7 +1,8 @@
 // Body Scan (Beta) — Client-side posture analysis using TensorFlow.js
 // This module runs locally in the browser. No files are uploaded.
 
-window.__fitlife_scan_booted = true;
+// Mark booted only after successful init; fallback relies on this flag
+window.__fitlife_scan_booted = false;
 
 import * as tf from 'https://cdn.jsdelivr.net/npm/@tensorflow/tfjs-core@4.13.0/dist/tf-core.esm.js';
 import 'https://cdn.jsdelivr.net/npm/@tensorflow/tfjs-backend-webgl@4.13.0/dist/tf-backend-webgl.esm.js';
@@ -32,6 +33,8 @@ async function ensureDetector() {
       enableSmoothing: true
     });
     setStatus(`Model ready (${tf.getBackend()})`);
+    // Model initialized successfully; mark module as booted so fallback defers
+    window.__fitlife_scan_booted = true;
     return detector;
   } catch (e) {
     console.warn('WebGL backend failed, falling back to WASM', e);
@@ -46,6 +49,7 @@ async function ensureDetector() {
         enableSmoothing: true
       });
       setStatus(`Model ready (${tf.getBackend()})`);
+      window.__fitlife_scan_booted = true;
       return detector;
     } catch (err) {
       console.error('Failed to initialize detector with WASM backend', err);

--- a/index.html
+++ b/index.html
@@ -8,8 +8,10 @@
     <meta property="og:title" content="FitLife — Fitness, Workouts, and Nutrition">
     <meta property="og:description" content="Calculators, workout builder, nutrition tracker, and more.">
     <meta property="og:type" content="website">
+    <meta name="theme-color" content="#07c0a2">
     <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
     <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Crect width='100' height='100' rx='16' fill='%2307c0a2'/%3E%3Ctext x='50' y='62' font-size='56' text-anchor='middle' fill='white' font-family='Arial, sans-serif'%3EF%3C/text%3E%3C/svg%3E">
+    <link rel="manifest" href="/manifest.webmanifest">
     <link rel="stylesheet" href="assets/css/styles.css?v=6">
   </head>
   <body>

--- a/manifest.webmanifest
+++ b/manifest.webmanifest
@@ -1,0 +1,15 @@
+{
+  "name": "FitLife — Fitness, Workouts, and Nutrition",
+  "short_name": "FitLife",
+  "start_url": "/",
+  "scope": "/",
+  "display": "standalone",
+  "background_color": "#0a0a0a",
+  "theme_color": "#07c0a2",
+  "icons": [
+    { "src": "/assets/icons/icon-192.png", "sizes": "192x192", "type": "image/png" },
+    { "src": "/assets/icons/icon-512.png", "sizes": "512x512", "type": "image/png" },
+    { "src": "/assets/icons/maskable-512.png", "sizes": "512x512", "type": "image/png", "purpose": "maskable" }
+  ]
+}
+

--- a/sw.js
+++ b/sw.js
@@ -1,0 +1,95 @@
+/* FitLife Service Worker */
+const CACHE_VERSION = 'v1';
+const CACHE_NAME = `fitlife-cache-${CACHE_VERSION}`;
+const ASSETS_TO_PRECACHE = [
+  '/',
+  '/index.html',
+  '/privacy.html',
+  '/terms.html',
+  '/assets/css/styles.css?v=6',
+  '/assets/js/main.js?v=6',
+  '/assets/js/scan-fallback.js?v=6',
+  '/assets/js/scan.js?v=6',
+];
+
+self.addEventListener('install', (event) => {
+  self.skipWaiting();
+  event.waitUntil(
+    caches.open(CACHE_NAME).then((cache) => cache.addAll(ASSETS_TO_PRECACHE)).catch(() => {})
+  );
+});
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil(
+    (async () => {
+      const keys = await caches.keys();
+      await Promise.all(keys.map((k) => { if (!k.startsWith('fitlife-cache-')) return; if (k !== CACHE_NAME) return caches.delete(k); }));
+      await self.clients.claim();
+    })()
+  );
+});
+
+function isSameOrigin(url) {
+  try { return new URL(url, self.location.origin).origin === self.location.origin; } catch { return false; }
+}
+
+self.addEventListener('fetch', (event) => {
+  const { request } = event;
+  if (request.method !== 'GET') return;
+
+  // Navigation requests: network-first with cache fallback (for offline)
+  if (request.mode === 'navigate') {
+    event.respondWith(
+      (async () => {
+        try {
+          const fresh = await fetch(request);
+          const cache = await caches.open(CACHE_NAME);
+          cache.put(request, fresh.clone()).catch(() => {});
+          return fresh;
+        } catch (_) {
+          const cache = await caches.open(CACHE_NAME);
+          const cached = await cache.match('/index.html');
+          return cached || new Response('<h1>Offline</h1><p>You appear to be offline.</p>', { headers: { 'Content-Type': 'text/html' } });
+        }
+      })()
+    );
+    return;
+  }
+
+  // Same-origin assets: cache-first
+  if (isSameOrigin(request.url)) {
+    event.respondWith(
+      (async () => {
+        const cache = await caches.open(CACHE_NAME);
+        const cached = await cache.match(request);
+        if (cached) return cached;
+        try {
+          const fresh = await fetch(request);
+          cache.put(request, fresh.clone()).catch(() => {});
+          return fresh;
+        } catch (_) {
+          return cached || Response.error();
+        }
+      })()
+    );
+    return;
+  }
+
+  // Cross-origin (e.g., CDN): stale-while-revalidate
+  event.respondWith(
+    (async () => {
+      const cache = await caches.open(CACHE_NAME);
+      const cached = await cache.match(request);
+      const networkPromise = fetch(request).then((resp) => {
+        cache.put(request, resp.clone()).catch(() => {});
+        return resp;
+      }).catch(() => null);
+      return cached || networkPromise || Response.error();
+    })()
+  );
+});
+
+self.addEventListener('message', (event) => {
+  if (event.data === 'SKIP_WAITING') self.skipWaiting();
+});
+


### PR DESCRIPTION
Add PWA features (service worker, manifest) and fix a bug in the Body Scan's guided analysis fallback.

The `__fitlife_scan_booted` flag was set too early, preventing the fallback from engaging when CDN model imports failed. This change ensures the flag is only set after successful model initialization, allowing the fallback to handle analysis if the primary model fails.

---
<a href="https://cursor.com/background-agent?bcId=bc-5230eb6c-f74b-4ac4-bcc9-a09cbc3a8393">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5230eb6c-f74b-4ac4-bcc9-a09cbc3a8393">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

